### PR TITLE
changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "github2es",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "--- github2es is a utility that serves as a walker to populate metadata from github for each package on npm's couch database to the corresponding ElasticSearch Documents forindexing. In order to not go over github's rate limit the module takes 10 packages at a time, gets the metadata from github, posts it to Elasticsearch, and waits 2000 ms until processing the next 10 packages.",
   "main": "github2es.js",
   "scripts": {


### PR DESCRIPTION
Stopped logging in errors to the console.
Passed in github env variable through the command line for testing. 
Also changes the way update to elastic search is done (uses doc instead of scripts in their dsl)
Kills the process when it cannot connect to a package page that is listed in the all docs
